### PR TITLE
Accessibility Suggestion

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -1135,7 +1135,7 @@
   padding: 0;
   -webkit-box-sizing: border-box;
   box-sizing: border-box;
-  outline: none;
+  outline-color: transparent;
 }
 
 *:not(i) {


### PR DESCRIPTION
Small accessibility defect in CSS when using "outline: none" was fixed. Made simple changes following best practices to prevent users with higher contrasts from experiencing bugs when using the tab key to select buttons, inputs, etc. Reference: https://www.youtube.com/shorts/4B_4WLpbyp8